### PR TITLE
Minor but major typo

### DIFF
--- a/PHP-Build/src/Plugswork/Plugswork.php
+++ b/PHP-Build/src/Plugswork/Plugswork.php
@@ -111,7 +111,7 @@ class Plugswork extends PluginBase{
                 "&6  |_|   |_|\__,_|\__, |___/ \_/\_/ \___/|_|  |_|\_\ \n".
                 "&6                 |___/                              \n".
                 "&b  Plugswork Version:&f v".PLUGSWORK_VERSION.".php\n".
-                "&3  (c) 2016 All right reserved, Plugswork.\n".
+                "&3  (c) 2016 All rights reserved, Plugswork.\n".
                 "&6  ".PwLang::cTranslate("main.donateNote")."\n"
                 )
         );


### PR DESCRIPTION
Google's copyright was made invalid when a tipi was made after maintenance that said "All right reserved" opposed to "All rights reserved". Google could have been copied! Similar thing with plugswork
